### PR TITLE
Fix platform check

### DIFF
--- a/boilerplate/certs/generate_local_ssl.sh
+++ b/boilerplate/certs/generate_local_ssl.sh
@@ -7,7 +7,7 @@ openssl req \
   -x509 \
   -subj "/C=US/ST=California/L=San Francisco/O=Twitch/OU=web/CN=localhost" \
   -extensions SAN \
-  -config <( cat $( [[ "Darwin" -eq "$(uname -s)" ]]  && echo /System/Library/OpenSSL/openssl.cnf || echo /etc/ssl/openssl.cnf  ) \
+  -config <( cat $( [[ "Darwin" = "$(uname -s)" ]]  && echo /System/Library/OpenSSL/openssl.cnf || echo /etc/ssl/openssl.cnf  ) \
     <(printf "[SAN]\nsubjectAltName='DNS:localhost'")) \
   -keyout "${NAME}.key" \
   -out "${NAME}.crt"


### PR DESCRIPTION
`-eq` checks numerical equality, `=` checks string equality, want the latter here.