### PR TITLE
Improve portability of generate_local_ssl.sh

### DIFF
--- a/boilerplate/certs/generate_local_ssl.sh
+++ b/boilerplate/certs/generate_local_ssl.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 NAME=${1:-testing}
 
 openssl req \


### PR DESCRIPTION
Add a shebang to the script, so that it can be run from different shells (such as fish).