### PR TITLE
Bits Fireworks v1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .DS_Store
+/bits-fireworks/ebs/ebs
+/bits-fireworks/ebs/vendor
+/bits-fireworks/ebs/Bits Fireworks.json

--- a/bits-fireworks/.gitignore
+++ b/bits-fireworks/.gitignore
@@ -1,5 +1,0 @@
-.DS_Store
-/ebs/vendor
-/ebs/server.key
-/ebs/server.crt
-/ebs/ebs

--- a/bits-fireworks/README.md
+++ b/bits-fireworks/README.md
@@ -3,6 +3,7 @@ An extension that demonstrates how to leverage [Bits](https://dev.twitch.tv/docs
 
 ![](fireworks.gif)
 
+
 ## What's in the sample
 The video-overlay extension allows viewers to spend Bits and trigger a fireworks animation on stream in return. When the broadcaster configures the extension, they select which of the two fireworks types they want to enable: Small (10 Bits) or Large (100 Bits).
 
@@ -13,7 +14,7 @@ The extension uses the [Configuration Service](https://dev.twitch.tv/docs/extens
 - OpenSSL. If on Windows, you can install Git which bundles it.  
 
 ## Installation 
-1. Create a new `Video - Fullscreen` extension. Select `Bits enabled` in the Monetization tab and `Extension Configuration Service` in the Capabilities tab. Record its `Client ID` and `Extension Secret`. 
+1. Create a new `Video - Fullscreen` extension. Select `Bits enabled` in the Monetization tab and `Extension Configuration Service` in the Capabilities tab. Set its Testing Base URI to `http://localhost:8080/` as we're not using HTTPS for example purposes. Record its `Client ID` and `Extension Secret`. 
 2. Load the extension in the [Developer Rig](https://github.com/twitchdev/developer-rig) to setup its [Bits Products Catalog](https://dev.twitch.tv/docs/extensions/monetization/#bits-product-catalog): 
 
 | Product Name     | SKU                 | Amount (in Bits) | In Development | Broadcast |
@@ -21,20 +22,17 @@ The extension uses the [Configuration Service](https://dev.twitch.tv/docs/extens
 | Small Fireworks  | small_fireworks_10  | 10               | Yes            | Yes       |
 | Large Fireworks  | large_fireworks_100 | 100              | Yes            | Yes       |
 
-3. Clone the repo under your `$GOPATH/src` directory.
-4. Navigate to the `ebs` directory; usually this would be `$GOPATH/src/github.com/twitchdev/extensions-samples/bits-fireworks/ebs`.
-4. Install the dependencies:
-`dep ensure`
-5. Generate the certificates for the EBS:
-`openssl req -nodes -x509 -newkey rsa:4096 -sha256 -keyout server.key -out server.crt -days 600 -subj '/CN=localhost'`
+3. Clone the repo under your `$GOPATH/src` directory and navigate to the `ebs` directory; usually this would be `$GOPATH/src/github.com/twitchdev/extensions-samples/bits-fireworks/ebs`.
+4. Install the dependencies: `dep ensure`.
 
 ## Usage
 
 1. Run the extension EBS:
 `go build && ./ebs -clientID <CLIENT_ID> -ownerID <OWNER_ID> -secret <SECRET>`
+
 The `OWNER_ID` is the user ID of the person who created the extension from Step 1 (you). To get the user ID, you will need to execute a simple cURL command against the Twitch API `/users` endpoint by passing your Twitch username:
 `curl -H "Client-ID: <client id>" -X GET "https://api.twitch.tv/helix/users?login=<username>"`
 
-To simplify development, the EBS also serves the front-end assets. You should see the "Launch Fireworks!" button if you open https://localhost:8080/video_overlay.html in your browser. 
+To simplify development, the EBS also serves the front-end assets. You should see the "Launch Fireworks!" button if you open http://localhost:8080/video_overlay.html in your browser. 
 
-2. Install and configure the extension on your channel. You can do so via the https://dev.twitch.tv/console/extensions/CLIENT_ID/0.0.1/status page (see the `View on Twitch and Install` button).
+2. Install and configure the extension on your channel. You can do so via the https://dev.twitch.tv/console/extensions/CLIENT_ID/0.0.1/status page (see the `View on Twitch and Install` button). Note that you must explicitly allow HTTP content to be loaded when viewing the extension on twitch.tv. For example, in Chrome, this is done by clicking on the shield icon in the right corner of the location bar.

--- a/bits-fireworks/client/config.html
+++ b/bits-fireworks/client/config.html
@@ -23,7 +23,7 @@ or in the "license" file accompanying this file. This file is distributed on an 
   <div class="nes-container is-dark with-title">
     <p class="title" id="configuration">Configuration</p>
     <div>
-      <button type="button" class="nes-btn is-primary" onclick="saveSettings()" id="btn_save">Save</button>
+      <button type="button" class="nes-btn is-primary" id="saveBtn">Save</button>
     </div>
   </div>
 </body>

--- a/bits-fireworks/client/js/config.js
+++ b/bits-fireworks/client/js/config.js
@@ -23,6 +23,20 @@ var twitch = window.Twitch ? window.Twitch.ext : null;
         return;
     }
 
+    window.onload = function () {
+        document.getElementById('saveBtn').addEventListener('click', function () {
+            var radioBtns = document.getElementsByName('firework');
+
+            for (var i = 0, length = radioBtns.length; i < length; i++) {
+                if (radioBtns[i].checked) {
+                    twitch.configuration.set("broadcaster", "", radioBtns[i].id);
+                    log("saveSettings() fired, broadcaster-selected sku set to: " + radioBtns[i].id);
+                    break;
+                }
+            }
+        });
+    }  
+
     twitch.configuration.onChanged(function () {
         sku = twitch.configuration.broadcaster ? twitch.configuration.broadcaster.content : ""
         log("onChanged() fired, previously broadcaster-selected sku: " + sku)
@@ -35,7 +49,6 @@ var twitch = window.Twitch ? window.Twitch.ext : null;
         for (var i = 0; i < products.length; i++) {
             var radioBtn = '<label><input type="radio" class="nes-radio is-dark" name="firework" id="' + products[i].sku + '" /><span>' + products[i].displayName + '</span></label>';
             elementsToRender.push(radioBtn);
-            log(radioBtn)
         }
         $("#configuration").after(elementsToRender);
 
@@ -45,26 +58,3 @@ var twitch = window.Twitch ? window.Twitch.ext : null;
         }
     });
 })()
-
-function saveSettings() {
-    var radioBtns = document.getElementsByName('firework');
-
-    for (var i = 0, length = radioBtns.length; i < length; i++) {
-        if (radioBtns[i].checked) {
-            twitch.configuration.set("broadcaster", "", radioBtns[i].id);
-            log("saveSettings() fired, broadcaster-selected sku set to: " + radioBtns[i].id);
-            break;
-        }
-    }
-}
-
-function compare(a, b) {
-    if (a.displayName > b.displayName) {
-        return -1;
-    }
-    if (a.displayName < b.displayName) {
-        return 1;
-    }
-
-    return 0;
-}

--- a/bits-fireworks/client/js/extension.js
+++ b/bits-fireworks/client/js/extension.js
@@ -19,6 +19,16 @@ log = function () {
     return Function.prototype.bind.call(console.log, console, prefix);
 }();
 
+compare = function(a, b) {
+    if (a.displayName > b.displayName) {
+        return -1;
+    }
+    if (a.displayName < b.displayName) {
+        return 1;
+    }
+    return 0;
+}
+
 window.requestAnimFrame = (function () {
     return window.requestAnimationFrame ||
         window.webkitRequestAnimationFrame ||

--- a/bits-fireworks/client/video_overlay.html
+++ b/bits-fireworks/client/video_overlay.html
@@ -25,7 +25,7 @@ or in the "license" file accompanying this file. This file is distributed on an 
     <img src="./images/small-glow.png" id="small-glow" />
   </aside>
   <div class="content">
-    <button type="button" class="nes-btn is-primary" id="fireworksBtn" onclick="useBits()">
+    <button type="button" class="nes-btn is-primary" id="fireworksBtn">
       Launch Fireworks!
     </button>
   </div>


### PR DESCRIPTION
- Remove use of HTTPS to simplify dev in Local Test
- Cleanup JS
- When calling the EBS, instead of passing the channel ID, pass the Twitch JWT instead (and later extract the channelID from it).